### PR TITLE
make iterutils work on py3

### DIFF
--- a/iterutils.py
+++ b/iterutils.py
@@ -7,6 +7,12 @@ by Alex Martelli on stackoverflow:
 http://stackoverflow.com/questions/1639772
 """
 
+try:
+    from itertools import ifilter, imap, izip
+except ImportError:
+    # We're on Python 3.X
+    ifilter, imap, izip = filter, map, zip
+
 from itertools import *
 
 iterutils_version = '0.1.6'


### PR DESCRIPTION
ifilter, imap, and izip were dropped from itertools in favor of replacing their builtin brethren. this lets iterutils transparently use the builtin versions on py3 while still using the itertools ones on py2.
